### PR TITLE
Adding ClientID in Header

### DIFF
--- a/twitch-api.js
+++ b/twitch-api.js
@@ -46,7 +46,8 @@ Twitch.prototype._createRequest = function(options, parameters){
     qs: parameters,
     headers: {
       'Authorization': options.accessToken?'OAuth ' + options.accessToken : undefined,
-      'Accept': 'Accept: application/vnd.twitchtv.v3+json'
+      'Accept': 'Accept: application/vnd.twitchtv.v3+json',
+      'Client-ID': this.clientId
     },
     body: options.body,
     json: true


### PR DESCRIPTION
It is always a good idea to add the client ID as HTTP Header to avoid running into rate limits (see https://github.com/justintv/Twitch-API/blob/master/README.md#rate-limits)
