### PR TITLE
+ Added refreshAccessToken API call

### DIFF
--- a/twitch-api.js
+++ b/twitch-api.js
@@ -137,6 +137,33 @@ Twitch.prototype.getAccessToken = function(code, callback){
 
 };
 
+/**
+ * Requests Twitch.tv for an accessCode for using your refresh token
+ *
+ * @param refresh_token {String} The code that twitch.tv's API sent in the
+ *        getAccessToken response
+ * @param callback {requestCallback} The callback that will manage the response.
+ */
+Twitch.prototype.refreshAccessToken = function(refresh_token, callback){
+  var parameters = {
+    client_id: this.clientId,
+    client_secret: this.clientSecret,
+    refresh_token : refresh_token,
+    grant_type: 'refresh_token',
+    redirect_uri: this.redirectUri
+  };
+
+  this._executeRequest(
+    {
+      method: 'POST',
+      path: accessTokenPath,
+    },
+    parameters,
+    callback
+  );
+
+};
+
 // ######  #       #######  #####  #    #  #####
 // #     # #       #     # #     # #   #  #     #
 // #     # #       #     # #       #  #   #


### PR DESCRIPTION
Adding support to [refresh](https://dev.twitch.tv/docs/authentication#refreshing-access-tokens) the _access_token_ since the tokens do now expire after a twitch-defined timeframe.

**refreshAccessToken(refresh_token, callback)** works exactly like the **getAccessToken**, _ refresh_token_ is being returned in the **getAccessToken** call.